### PR TITLE
Close flash via click

### DIFF
--- a/app/assets/images/icons/x-circle.svg
+++ b/app/assets/images/icons/x-circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+</svg>

--- a/app/javascript/controllers/removeable_controller.js
+++ b/app/javascript/controllers/removeable_controller.js
@@ -15,6 +15,7 @@ export default class extends Controller {
   }
 
   remove() {
+    if (this.removeTid) clearTimeout(this.removeTid);
     this.element.remove();
   }
 }

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -2,14 +2,16 @@
 <div class="fixed z-50 right-0 mr-4 top-0 mt-[80px]" id="flash">
   <div class="flex justify-center">
     <% if flash[:notice] %>
-      <div class="flash notice" role="alert" data-turbo-temporary data-controller="removeable" data-removeable-after-value="5">
+      <div class="flash notice flex gap-3 items-center" role="alert" data-turbo-temporary data-controller="removeable" data-removeable-after-value="5">
         <p class="text-small"><%= flash[:notice] %></p>
+        <%= image_tag "icons/x-circle.svg", class: "w-4 h-4 cursor-pointer", data: { action: "click->removeable#remove" }  %>
       </div>
     <% end %>
 
     <% if flash[:alert] %>
-      <div class="flash alert" role="alert" data-turbo-temporary data-controller="removeable" data-removeable-after-value="5">
+      <div class="flash alert flex gap-3 items-center" role="alert" data-turbo-temporary data-controller="removeable" data-removeable-after-value="5">
         <p class="text-small"><%= flash[:alert] %></p>
+        <%= image_tag "icons/x-circle.svg", class: "w-4 h-4 cursor-pointer", data: { action: "click->removeable#remove" }  %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## Проблема

Мы добавили автоматическое скрывание flash-уведомлений через определённое время. Однако у пользователей нет никакой возможности закрыть их «досрочно».

## Задача

Добавить «крестик» к окошкам уведомлений, по клику на который уведомление будет скрыто сразу же.